### PR TITLE
Remove condition in ref-checker

### DIFF
--- a/kaart.dwarf.validator.mapcss
+++ b/kaart.dwarf.validator.mapcss
@@ -98,7 +98,6 @@ way[highway][noname].kaart_user {
 /* Checks if ref and name tag are present and if name and ref are equal. Also checks for "Rodovia REF-1000" or ref tag in name/alt_name */
 /* RD Clare, Andrew Piechota */
 way[highway][highway !~ /residential|living_street|service|pedestrian|track|escape|raceway|footway|bridleway|steps|path|cycleway|proposed|construction/][name][ref][name = *ref],
-way[highway][highway !~ /residential|living_street|service|pedestrian|track|escape|raceway|footway|bridleway|steps|path|cycleway|proposed|construction/][/^(name|alt_name)$/ =~ /(Rodovia|Estrada|Travessa|Rua|Avenida|Alameda|Viela|Servid(a|ã)o|Acesso|Beco|Pra(c|ç)a|Caminho|Ponte|Viaduto) ([a-zA-Z]{2,3}-?[0-9]{2,4})/],
 way[highway][highway !~ /residential|living_street|service|pedestrian|track|escape|raceway|footway|bridleway|steps|path|cycleway|proposed|construction/][/^(name|alt_name)$/ =~ /([a-zA-Z]{2,3}-?[0-9]{2,4})/] {
   throwWarning: tr("Name/Alt_name may contain ref");
   group: tr(kaart_dwarf);


### PR DESCRIPTION
Searching for prefixes flagged too many false positives w/ the ref-checker. Roads such as Avenida LO-23 were flagged was refs, when in fact, that is just their name. If this doesn't help, possible add the additional condition that the name/alt_name cannot have a prefix present.